### PR TITLE
Add support for opening entries in a Horizontal Split

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,18 @@ This extension contributes the following settings:
 * `peekBorderColor`: Change the peek color ('white', '#FFF' '#FFFFFFF', 'rgb(255,255,255)','rgba(255, 255, 255. 0.5) )
 * `peekBorderWidth`: Change the peek border width (px)
 * `peekBorderStyle`: Change the peek border style (solid, dashed, inset, double, groove, outset, ridge)
+
+### Other commands
+
+#### periscope.openInHorizontalSplit
+
+Open the selected entry in a horizontal split.
+
+Add a keybinding (`keybindings.json`):
+```json
+  {
+    "key": "ctrl+v",
+    "command": "periscope.openInHorizontalSplit",
+    "when": "periscopeActive"
+  }
+```

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,16 @@
 import * as vscode from 'vscode';
-import { periscope } from './periscope';
+import { openInHorizontalSplit, periscope } from './periscope';
 
 export function activate(context: vscode.ExtensionContext) {
   console.log('<<PERISCOPE>> is now active.');
 
-  const disposable = vscode.commands.registerCommand(
-    'periscope.search',
+  const periscopeQpCmd = vscode.commands.registerCommand('periscope.search',
     () => periscope().register()
   );
-  context.subscriptions.push(disposable);
+
+  const periscopeSplitCmd = vscode.commands.registerCommand("periscope.openInHorizontalSplit", () => {
+    openInHorizontalSplit();
+  });
+
+  context.subscriptions.push(periscopeQpCmd, periscopeSplitCmd);
 }

--- a/src/periscope.ts
+++ b/src/periscope.ts
@@ -187,7 +187,7 @@ export const periscope = () => {
   }
 
   // when item button is 'TRIGGERED'
-  function onDidTriggerItemButton(e: vscode.QuickPickItemButtonEvent<QPItemQuery>) {
+  function onDidTriggerItemButton(e: vscode.QuickPickItemButtonEvent<AllQPItemVariants>) {
     console.log('PERISCOPE: item button triggered');
     if (e.item._type === 'QuickPickItemQuery') {
       accept(e.item as QPItemQuery);
@@ -336,7 +336,7 @@ export const periscope = () => {
 
       if(item) { // horizontal split
         options.viewColumn = vscode.ViewColumn.Beside;
-        previousActiveEditor = undefined; // prevent focus previous editor
+        closePreviewEditor();
       }
 
       vscode.window.showTextDocument(document, options).then(editor => {
@@ -479,15 +479,24 @@ export const openInHorizontalSplit = () => {
     viewColumn: vscode.ViewColumn.Beside,
   };
 
+  closePreviewEditor();
+
   const { filePath, linePos, colPos } = currentItem.data;
-  vscode.workspace.openTextDocument(filePath).then(document => {
-      vscode.window.showTextDocument(document, options).then(editor => {
-          // set cursor & view position
-          const position = new vscode.Position(linePos, colPos);
-          editor.revealRange(new vscode.Range(position, position));
-          previousActiveEditor = undefined; // prevent focus previous editor
-          activeQP?.dispose();
-      });
+  vscode.workspace.openTextDocument(filePath).then((document) => {
+    vscode.window.showTextDocument(document, options).then((editor) => {
+      // set cursor & view position
+      const position = new vscode.Position(linePos, colPos);
+      editor.revealRange(new vscode.Range(position, position));
+      activeQP?.dispose();
+    });
   });
 };
+
+function closePreviewEditor() {
+  if(previousActiveEditor) {
+    vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+    previousActiveEditor = undefined; // prevent focus onDidHide
+  }
+}
+
 


### PR DESCRIPTION
Changes:
- Added a `QuickPickItem` button to open the file in a split 
- Added new command `periscope.openInHorizontalSplit` to open the selected item via keybinding

Demo:

https://github.com/joshmu/periscope/assets/1500881/06994dda-39ae-4665-975f-606d2d06c232

(The first time I open the file is via a keybinding)

