### PR TITLE
Use the vscode bundled ripgrep

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ _Inspired by nvim's [telescope](https://github.com/nvim-telescope/telescope.nvim
 2. Input your query and move through the suggested results, the editor will reflect the current highlighted suggested item.
 3. Hit enter to open the file or cancel to return to your original active editor
 
-## Requirements
-
-[Install ripgrep](https://github.com/BurntSushi/ripgrep#installation)
-
 ## Extension Settings
 
 This extension contributes the following settings:
@@ -28,6 +24,7 @@ This extension contributes the following settings:
 
 * `rgOptions`: Additional options to pass to the 'rg' command, you can view all options in your terminal via 'rg --help'.
 * `rgGlobExcludes`: Additional glob paths to exclude from the 'rg' search, eg: '__/dist/__'.
+* `rgPath`: Optional path to the `rg` binary. If not specified, the ripgrep bundled with vscode will be used.
 * `addSrcPaths`: Additional source paths to include in the rg search. You may want to add this as a workspace specific setting.
 * `rgMenuActions`: Create menu items which can be selected prior to any query, these items will be added to the ripgrep command to generate the results. Eg: Add  `{ label: "JS/TS", value: "--type-add 'jsts:*.{js|ts|tsx|jsx}' -t jsts" },` as a menu option to only show js & ts files in the results.
 * `startFolderDisplayDepth`: The folder depth to display in the results before '...'.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
           },
           "description": "Additional options to pass to the 'rg' command, you can view all options in your terminal via 'rg --help'."
         },
+        "periscope.rgPath": {
+          "type": "string",
+          "description": "Override the path to the 'rg' command, eg: '/usr/local/bin/rg'. If not specified, the bundled vscode rg will be used."
+        },
         "periscope.rgGlobExcludes": {
           "type": "array",
           "default": [],

--- a/src/periscope.ts
+++ b/src/periscope.ts
@@ -273,6 +273,8 @@ export const periscope = () => {
   }
 
   function rgCommand(value: string) {
+    const rgPath = ripgrepPath(config.rgPath);
+
     const rgRequiredFlags = [
       '--line-number',
       '--column',
@@ -298,7 +300,7 @@ export const periscope = () => {
       ...excludes,
     ];
 
-    return `rg '${value}' ${rgFlags.join(' ')}`;
+    return `"${rgPath}" '${value}' ${rgFlags.join(' ')}`;
   }
 
   function peekItem(items: readonly QPItemQuery[]) {
@@ -499,4 +501,17 @@ function closePreviewEditor() {
   }
 }
 
+// grap the bundled ripgrep binary from vscode
+function ripgrepPath(optionsPath?: string) {
+  if(optionsPath?.trim()) {
+    return optionsPath.trim();
+  }
 
+  const rgBinary = /^win/.test(process.platform) ? "rg.exe" : "rg";
+
+  return path.join(
+    vscode.env.appRoot,
+    "node_modules.asar.unpacked/@vscode/ripgrep/bin/",
+    rgBinary
+  );
+}

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -6,6 +6,7 @@ type ConfigItems =
   | 'addSrcPaths'
   | 'rgGlobExcludes'
   | 'rgMenuActions'
+  | 'rgPath'
   | 'startFolderDisplayDepth'
   | 'endFolderDisplayDepth'
   | 'alwaysShowRgMenuActions'
@@ -27,6 +28,7 @@ export function getConfig() {
     addSrcPaths: vsConfig.get<string[]>('addSrcPaths', []),
     rgGlobExcludes: vsConfig.get<string[]>('rgGlobExcludes', []),
     rgMenuActions: vsConfig.get<{label?: string, value: string}[]>('rgMenuActions', []),
+    rgPath: vsConfig.get<string | undefined>('rgPath', undefined),
     startFolderDisplayDepth: vsConfig.get<number>('startFolderDisplayDepth', 1),
     endFolderDisplayDepth: vsConfig.get<number>('endFolderDisplayDepth', 4),
     alwaysShowRgMenuActions: vsConfig.get<boolean>(


### PR DESCRIPTION
Seems to work fine on my end (macos), didn't test it property on linux/windows but should work.

Also added a setting to override the `rg` path just in case.