### PR TITLE
Add rgQueryParams setting to allow rp filtering from the query input

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ _Inspired by nvim's [telescope](https://github.com/nvim-telescope/telescope.nvim
 2. Input your query and move through the suggested results, the editor will reflect the current highlighted suggested item.
 3. Hit enter to open the file or cancel to return to your original active editor
 
-## Requirements
-
-[Install ripgrep](https://github.com/BurntSushi/ripgrep#installation)
-
 ## Extension Settings
 
 This extension contributes the following settings:
@@ -28,6 +24,7 @@ This extension contributes the following settings:
 
 * `rgOptions`: Additional options to pass to the 'rg' command, you can view all options in your terminal via 'rg --help'.
 * `rgGlobExcludes`: Additional glob paths to exclude from the 'rg' search, eg: '__/dist/__'.
+* `rgPath`: Optional path to the `rg` binary. If not specified, the ripgrep bundled with vscode will be used.
 * `addSrcPaths`: Additional source paths to include in the rg search. You may want to add this as a workspace specific setting.
 * `rgMenuActions`: Create menu items which can be selected prior to any query, these items will be added to the ripgrep command to generate the results. Eg: Add  `{ label: "JS/TS", value: "--type-add 'jsts:*.{js|ts|tsx|jsx}' -t jsts" },` as a menu option to only show js & ts files in the results.
 * `startFolderDisplayDepth`: The folder depth to display in the results before '...'.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ This extension contributes the following settings:
 * `rgGlobExcludes`: Additional glob paths to exclude from the 'rg' search, eg: '__/dist/__'.
 * `rgPath`: Optional path to the `rg` binary. If not specified, the ripgrep bundled with vscode will be used.
 * `addSrcPaths`: Additional source paths to include in the rg search. You may want to add this as a workspace specific setting.
-* `rgMenuActions`: Create menu items which can be selected prior to any query, these items will be added to the ripgrep command to generate the results. Eg: Add  `{ label: "JS/TS", value: "--type-add 'jsts:*.{js|ts|tsx|jsx}' -t jsts" },` as a menu option to only show js & ts files in the results.
+* `rgMenuActions`: Create menu items which can be selected prior to any query, these items will be added to the ripgrep command to generate the results. Eg: Add  `{ "label": "JS/TS", "value": "--type-add 'jsts:*.{js|ts|tsx|jsx}' -t jsts" },` as a menu option to only show js & ts files in the results.
+* `rgQueryParams`: Match ripgrep parameters from the input query directly. E.g: `{ "param": \"-t $1\", "regex": \"^(.+) -t ?(\\w+)$\" },` will translate the query `hello -t rust` to `rg 'hello' -t rust`.
 * `startFolderDisplayDepth`: The folder depth to display in the results before '...'.
 * `endFolderDisplayDepth`: The folder depth to display in the results after '...'.
 * `alwaysShowRgMenuActions`: If true, then open rg menu actions every time the search is invoked.

--- a/package.json
+++ b/package.json
@@ -79,6 +79,28 @@
           },
           "description": "Create menu items which can be selected prior to any query, these items will be added to the ripgrep command to generate the results. Eg: Add  `{ label: \"JS/TS\", value: \"--type-add 'jsts:*.{js|ts|tsx|jsx}' -t jsts\" },` as a menu option to only show js & ts files in the results."
         },
+        "periscope.rgQueryParams": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "object",
+            "properties": {
+              "param": {
+                "type": "string",
+                "description": "The rg params to translate to (e.g -t $1, -g '$1')."
+              },
+              "regex": {
+                "type": "string",
+                "description": "The regex to match the query and capture the value to pass to the rg param (e.g `^(.+) -t ?(\\w+)$`)"
+              }
+            },
+            "required": [
+              "param",
+              "regex"
+            ]
+          },
+          "description": "Match ripgrep parameters from the input query directly. E.g: `{ param: \"-t $1\", regex: \"^(.+) -t ?(\\w+)$\" },` will translate the query `hello -t rust` to `rg 'hello' -t rust`"
+        },
         "periscope.startFolderDisplayDepth": {
           "type": "number",
           "default": 1,

--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
           },
           "description": "Additional options to pass to the 'rg' command, you can view all options in your terminal via 'rg --help'."
         },
+        "periscope.rgPath": {
+          "type": "string",
+          "description": "Override the path to the 'rg' command, eg: '/usr/local/bin/rg'. If not specified, the bundled vscode rg will be used."
+        },
         "periscope.rgGlobExcludes": {
           "type": "array",
           "default": [],

--- a/src/periscope.ts
+++ b/src/periscope.ts
@@ -170,7 +170,13 @@ export const periscope = () => {
         return;
       }
 
-      search(value);
+      if(config.rgQueryParams.length > 0) {
+        const { newQuery, extraRgFlags } = extraRgFlagsFromQuery(value);
+        query = newQuery; // update query for later use
+        search(newQuery, extraRgFlags);
+      } else {
+        search(value);
+      }
     } else {
       qp.items = [];
     }
@@ -208,9 +214,9 @@ export const periscope = () => {
     finished();
   }
 
-  function search(value: string) {
+  function search(value: string, rgExtraFlags?: string[]) {
     qp.busy = true;
-    const rgCmd = rgCommand(value);
+    const rgCmd = rgCommand(value, rgExtraFlags);
     console.log('PERISCOPE: rgCmd:', rgCmd);
 
     checkKillProcess();
@@ -272,7 +278,7 @@ export const periscope = () => {
     }
   }
 
-  function rgCommand(value: string) {
+  function rgCommand(value: string, extraFlags?: string[]) {
     const rgPath = ripgrepPath(config.rgPath);
 
     const rgRequiredFlags = [
@@ -297,10 +303,38 @@ export const periscope = () => {
       ...rgMenuActionsSelected,
       ...rootPaths,
       ...config.addSrcPaths,
+      ...(extraFlags || []),
       ...excludes,
     ];
 
     return `"${rgPath}" '${value}' ${rgFlags.join(' ')}`;
+  }
+
+  // extract rg flags from the query, can match multiple regex's
+  function extraRgFlagsFromQuery(query: string): {
+    newQuery: string;
+    extraRgFlags: string[];
+  } {
+    const extraRgFlags: string[] = [];
+    const queries = [query];
+
+    for (const { param, regex } of config.rgQueryParams) {
+      if (param && regex) {
+        const match = query.match(regex);
+        if (match && match.length > 1) {
+          let newParam = param;
+          for (let i = 2; i < match.length; i++) {
+            newParam = newParam.replace(`$${i-1}`, match[i]);
+          }
+          extraRgFlags.push(newParam);
+          queries.push(match[1]);
+        }
+      }
+    }
+
+    // prefer the first query match or the original one
+    const newQuery = queries.length > 1 ? queries[1] : queries[0];
+    return { newQuery, extraRgFlags };
   }
 
   function peekItem(items: readonly QPItemQuery[]) {

--- a/src/periscope.ts
+++ b/src/periscope.ts
@@ -273,6 +273,8 @@ export const periscope = () => {
   }
 
   function rgCommand(value: string) {
+    const rgPath = ripgrepPath(config.rgPath);
+
     const rgRequiredFlags = [
       '--line-number',
       '--column',
@@ -298,7 +300,7 @@ export const periscope = () => {
       ...excludes,
     ];
 
-    return `rg '${value}' ${rgFlags.join(' ')}`;
+    return `"${rgPath}" '${value}' ${rgFlags.join(' ')}`;
   }
 
   function peekItem(items: readonly QPItemQuery[]) {
@@ -499,4 +501,17 @@ function closePreviewEditor() {
   }
 }
 
+// grap the bundled ripgrep binary from vscode
+function ripgrepPath(optionsPath?: string) {
+  if(optionsPath?.trim()) {
+    return optionsPath.trim();
+  }
 
+  const rgBinary = /^win/.test(process.platform) ? "rg.exe" : "rg";
+
+  return path.join(
+    vscode.env.appRoot,
+    "node_modules.asar.unpacked/@vscode/ripgrep/bin/",
+    rgBinary
+  );
+}

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -6,6 +6,7 @@ type ConfigItems =
   | 'addSrcPaths'
   | 'rgGlobExcludes'
   | 'rgMenuActions'
+  | 'rgPath'
   | 'startFolderDisplayDepth'
   | 'endFolderDisplayDepth'
   | 'alwaysShowRgMenuActions'
@@ -27,6 +28,7 @@ export function getConfig() {
     addSrcPaths: vsConfig.get<string[]>('addSrcPaths', []),
     rgGlobExcludes: vsConfig.get<string[]>('rgGlobExcludes', []),
     rgMenuActions: vsConfig.get<{label?: string, value: string}[]>('rgMenuActions', []),
+    rgPath: vsConfig.get<string | undefined>('rgPath', undefined),
     startFolderDisplayDepth: vsConfig.get<number>('startFolderDisplayDepth', 1),
     endFolderDisplayDepth: vsConfig.get<number>('endFolderDisplayDepth', 4),
     alwaysShowRgMenuActions: vsConfig.get<boolean>(

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -6,6 +6,7 @@ type ConfigItems =
   | 'addSrcPaths'
   | 'rgGlobExcludes'
   | 'rgMenuActions'
+  | 'rgQueryParams'
   | 'rgPath'
   | 'startFolderDisplayDepth'
   | 'endFolderDisplayDepth'
@@ -28,6 +29,7 @@ export function getConfig() {
     addSrcPaths: vsConfig.get<string[]>('addSrcPaths', []),
     rgGlobExcludes: vsConfig.get<string[]>('rgGlobExcludes', []),
     rgMenuActions: vsConfig.get<{label?: string, value: string}[]>('rgMenuActions', []),
+    rgQueryParams: vsConfig.get<{param?: string, regex: string}[]>('rgQueryParams', []),
     rgPath: vsConfig.get<string | undefined>('rgPath', undefined),
     startFolderDisplayDepth: vsConfig.get<number>('startFolderDisplayDepth', 1),
     endFolderDisplayDepth: vsConfig.get<number>('endFolderDisplayDepth', 4),


### PR DESCRIPTION
Changes:
- Added new setting `rgQueryParams`

The updated readme and examples should give you an idea of how it works, let me know if you want a demo :).

My use cases for this setting:
```json
  "periscope.rgQueryParams": [
    {
      // filter the results to a folder
      // Query: redis -m module1 => rg 'redis' -g '**/*module1*/**'
      "param": "-g '**/*$1*/**' -g '!**/node_modules/**'",
      "regex": "^(.+) -m ([\\w-_]+)$"
    },
    {
      // filter the results to a folder and filetype
      // Query: redis -m module1 yaml => rg 'redis' -g '**/*module1*/**/*.yaml'
      "param": "-g '**/*$1*/**/*.$2'",
      "regex": "^(.+) -m ([\\w-_]+) ([\\w]+)$"
    },
    {
      // filter the results that match a glob
      // Query: redis -g *module => rg 'redis' -g '*module'
      "param": "-g '$1'",
      "regex": "^(.+) -g (.+)$"
    },
    {
      // filter the results to rg filetypes
      // Query: redis -t yaml => rg 'redis' -t yaml
      "param": "-t $1",
      "regex": "^(.+) -t ?(\\w+)$"
    },
    {
      // filter the results that match a file extension through a glob
      // Query: redis *.rs => rg 'redis' -g '*.rs'
      "param": "-g '*.$1'",
      "regex": "^(.+) \\*\\.(\\w+)$"
    }
  ],
```

Ignore the commit from the other PR that is not merged yet, I'll rebase this PR after merging that one.