### PR TITLE
Options to configure start folder index, hide previous results and new title bar when using regex matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ This extension contributes the following settings:
 - `addSrcPaths`: Additional source paths to include in the rg search. You may want to add this as a workspace specific setting.
 - `rgMenuActions`: Create menu items which can be selected prior to any query, these items will be added to the ripgrep command to generate the results. Eg: Add `{ "label": "JS/TS", "value": "--type-add 'jsts:*.{js|ts|tsx|jsx}' -t jsts" },` as a menu option to only show js & ts files in the results.
 - `rgQueryParams`: Match ripgrep parameters from the input query directly. E.g: `{ "param": \"-t $1\", "regex": \"^(.+) -t ?(\\w+)$\" },` will translate the query `hello -t rust` to `rg 'hello' -t rust`.
+- `startFolderDisplayIndex`: The folder index to display in the results before '...'.
 - `startFolderDisplayDepth`: The folder depth to display in the results before '...'.
 - `endFolderDisplayDepth`: The folder depth to display in the results after '...'.
 - `alwaysShowRgMenuActions`: If true, then open rg menu actions every time the search is invoked.
+- `showPreviousResultsWhenNoMatches`: If true (default), when there are no matches for the current query, the previous results will still be shown.
 - `gotoRgMenuActionsPrefix`: If the query starts with this prefix, then open rg menu actions.
 - `enableGotoNativeSearch`: If true, then swap to native vscode search if the custom suffix is entered using the current query.
 - `gotoNativeSearchSuffix`: If the query ends with this suffix, then swap to the native search with the query applied.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This extension contributes the following settings:
 - `startFolderDisplayDepth`: The folder depth to display in the results before '...'.
 - `endFolderDisplayDepth`: The folder depth to display in the results after '...'.
 - `alwaysShowRgMenuActions`: If true, then open rg menu actions every time the search is invoked.
-- `showPreviousResultsWhenNoMatches`: If true (default), when there are no matches for the current query, the previous results will still be shown.
+- `showPreviousResultsWhenNoMatches`: If true, when there are no matches for the current query, the previous results will still be shown.
 - `gotoRgMenuActionsPrefix`: If the query starts with this prefix, then open rg menu actions.
 - `enableGotoNativeSearch`: If true, then swap to native vscode search if the custom suffix is entered using the current query.
 - `gotoNativeSearchSuffix`: If the query ends with this suffix, then swap to the native search with the query applied.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This extension contributes the following settings:
 - `addSrcPaths`: Additional source paths to include in the rg search. You may want to add this as a workspace specific setting.
 - `rgMenuActions`: Create menu items which can be selected prior to any query, these items will be added to the ripgrep command to generate the results. Eg: Add `{ "label": "JS/TS", "value": "--type-add 'jsts:*.{js|ts|tsx|jsx}' -t jsts" },` as a menu option to only show js & ts files in the results.
 - `rgQueryParams`: Match ripgrep parameters from the input query directly. E.g: `{ "param": \"-t $1\", "regex": \"^(.+) -t ?(\\w+)$\" },` will translate the query `hello -t rust` to `rg 'hello' -t rust`.
+- `rgQueryParamsShowTitle`: When a ripgrep parameter match from the list in `rgQueryParams`, the quick pick will show the matched result as a preview in the title bar.
 - `startFolderDisplayIndex`: The folder index to display in the results before '...'.
 - `startFolderDisplayDepth`: The folder depth to display in the results before '...'.
 - `endFolderDisplayDepth`: The folder depth to display in the results after '...'.

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
         },
         "periscope.showPreviousResultsWhenNoMatches": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "If true, when there are no matches for the current query, the previous results will still be shown."
         },
         "periscope.gotoRgMenuActionsPrefix": {

--- a/package.json
+++ b/package.json
@@ -126,6 +126,11 @@
           "default": true,
           "description": "If true, then open rg menu actions every time the search is invoked."
         },
+        "periscope.rgQueryParamsShowTitle": {
+          "type": "boolean",
+          "default": true,
+          "description": "If true, when a ripgrep parameter match from the list in `rgQueryParams`, the quick pick will show the matched result as a preview in the title bar."
+        },
         "periscope.showPreviousResultsWhenNoMatches": {
           "type": "boolean",
           "default": false,

--- a/package.json
+++ b/package.json
@@ -106,6 +106,11 @@
           },
           "description": "Match ripgrep parameters from the input query directly. E.g: `{ param: \"-t $1\", regex: \"^(.+) -t ?(\\w+)$\" },` will translate the query `hello -t rust` to `rg 'hello' -t rust`"
         },
+        "periscope.startFolderDisplayIndex": {
+          "type": "number",
+          "default": 0,
+          "description": "The folder index to display in the results before truncating with '...'."
+        },
         "periscope.startFolderDisplayDepth": {
           "type": "number",
           "default": 1,
@@ -120,6 +125,11 @@
           "type": "boolean",
           "default": true,
           "description": "If true, then open rg menu actions every time the search is invoked."
+        },
+        "periscope.showPreviousResultsWhenNoMatches": {
+          "type": "boolean",
+          "default": true,
+          "description": "If true, when there are no matches for the current query, the previous results will still be shown."
         },
         "periscope.gotoRgMenuActionsPrefix": {
           "type": "string",

--- a/src/periscope.ts
+++ b/src/periscope.ts
@@ -174,6 +174,7 @@ export const periscope = () => {
       if(config.rgQueryParams.length > 0) {
         const { newQuery, extraRgFlags } = extraRgFlagsFromQuery(value);
         query = newQuery; // update query for later use
+        qp.title = extraRgFlags.length > 0 ? `rg '${query}' ${extraRgFlags.join(' ')}` : undefined;
         search(newQuery, extraRgFlags);
       } else {
         search(value);

--- a/src/periscope.ts
+++ b/src/periscope.ts
@@ -1,10 +1,10 @@
-import * as vscode from 'vscode';
-import * as path from 'path';
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { rgPath } from 'vscode-ripgrep';
+import { highlightDecorationType } from './utils/decorationType';
 import { getConfig } from './utils/getConfig';
 import { getSelectedText } from './utils/getSelectedText';
-import { highlightDecorationType } from './utils/decorationType';
-import { rgPath } from 'vscode-ripgrep';
 
 export interface QPItemDefault extends vscode.QuickPickItem {
   _type: 'QuickPickItemDefault'
@@ -174,7 +174,11 @@ export const periscope = () => {
       if(config.rgQueryParams.length > 0) {
         const { newQuery, extraRgFlags } = extraRgFlagsFromQuery(value);
         query = newQuery; // update query for later use
-        qp.title = extraRgFlags.length > 0 ? `rg '${query}' ${extraRgFlags.join(' ')}` : undefined;
+
+        if(config.rgQueryParamsShowTitle) { // update title with preview
+          qp.title = extraRgFlags.length > 0 ? `rg '${query}' ${extraRgFlags.join(' ')}` : undefined;
+        }
+
         search(newQuery, extraRgFlags);
       } else {
         search(value);

--- a/src/periscope.ts
+++ b/src/periscope.ts
@@ -264,6 +264,10 @@ export const periscope = () => {
         );
       } else if (code === 1) {
         console.log(`PERISCOPE: rg exited with code ${code}`);
+        if(!config.showPreviousResultsWhenNoMatches) {
+          // hide the previous results if no results found
+          qp.items = [];
+        }
       } else if (code === 2) {
         console.error('PERISCOPE: No matches found');
       } else {
@@ -458,7 +462,7 @@ export const periscope = () => {
       folders.length >
       config.startFolderDisplayDepth + config.endFolderDisplayDepth
     ) {
-      const initialFolders = folders.splice(0, config.startFolderDisplayDepth);
+      const initialFolders = folders.splice(config.startFolderDisplayIndex, config.startFolderDisplayDepth);
       folders.splice(0, folders.length - config.endFolderDisplayDepth);
       folders.unshift(...initialFolders, '...');
     }

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -7,6 +7,7 @@ type ConfigItems =
   | 'rgGlobExcludes'
   | 'rgMenuActions'
   | 'rgQueryParams'
+  | 'rgQueryParamsShowTitle'
   | 'rgPath'
   | 'startFolderDisplayDepth'
   | 'startFolderDisplayIndex'
@@ -32,6 +33,10 @@ export function getConfig() {
     rgGlobExcludes: vsConfig.get<string[]>('rgGlobExcludes', []),
     rgMenuActions: vsConfig.get<{label?: string, value: string}[]>('rgMenuActions', []),
     rgQueryParams: vsConfig.get<{param?: string, regex: string}[]>('rgQueryParams', []),
+    rgQueryParamsShowTitle: vsConfig.get<boolean>(
+      'rgQueryParamsShowTitle',
+      true
+    ),
     rgPath: vsConfig.get<string | undefined>('rgPath', undefined),
     startFolderDisplayIndex: vsConfig.get<number>('startFolderDisplayIndex', 0),
     startFolderDisplayDepth: vsConfig.get<number>('startFolderDisplayDepth', 1),

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -42,7 +42,7 @@ export function getConfig() {
     ),
     showPreviousResultsWhenNoMatches: vsConfig.get<boolean>(
       'showPreviousResultsWhenNoMatches',
-      true
+      false
     ),
     gotoRgMenuActionsPrefix:
       vsConfig.get<string>('gotoRgMenuActionsPrefix', '<<') || '<<',

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -9,8 +9,10 @@ type ConfigItems =
   | 'rgQueryParams'
   | 'rgPath'
   | 'startFolderDisplayDepth'
+  | 'startFolderDisplayIndex'
   | 'endFolderDisplayDepth'
   | 'alwaysShowRgMenuActions'
+  | 'showPreviousResultsWhenNoMatches'
   | 'gotoRgMenuActionsPrefix'
   | 'enableGotoNativeSearch'
   | 'gotoNativeSearchSuffix'
@@ -31,10 +33,15 @@ export function getConfig() {
     rgMenuActions: vsConfig.get<{label?: string, value: string}[]>('rgMenuActions', []),
     rgQueryParams: vsConfig.get<{param?: string, regex: string}[]>('rgQueryParams', []),
     rgPath: vsConfig.get<string | undefined>('rgPath', undefined),
+    startFolderDisplayIndex: vsConfig.get<number>('startFolderDisplayIndex', 0),
     startFolderDisplayDepth: vsConfig.get<number>('startFolderDisplayDepth', 1),
     endFolderDisplayDepth: vsConfig.get<number>('endFolderDisplayDepth', 4),
     alwaysShowRgMenuActions: vsConfig.get<boolean>(
       'alwaysShowRgMenuActions',
+      true
+    ),
+    showPreviousResultsWhenNoMatches: vsConfig.get<boolean>(
+      'showPreviousResultsWhenNoMatches',
       true
     ),
     gotoRgMenuActionsPrefix:


### PR DESCRIPTION
Hey 👋 

Adding 3 new small improvements:
- New option `startFolderDisplayIndex` that allows to customise the first folder shown in the results. 
  - For my taste, I prefer to start at index `1` instead of `0` because it's a bit pointless to see the the workspace folder taking up space on every item. And since I work with monorepos, the folder at index `1` is more useful for me because it's the app name. I've kept the default as `0` since it's the current behaviour.
 - New option `showPreviousResultsWhenNoMatches` to clear the results if there are no matches for the current query. Defaults to `true` since it's the current behaviour.
   - I prefer to have strong visual indication (no results instead of vscode no bold match the results) when there are no matches for the current query, I then know that I should tweak my query.
 - New functionality to show the QuickPick title bar when using the regex param matches. When there is a match, we show a 'preview' of the `rg` expanded params in the title. 

## Demo

https://github.com/joshmu/periscope/assets/1500881/95d2c4bc-ad07-4353-b2af-f5766f287b6b

In the video I'm hiding the results when the query doesn't match anything. You can see the title bar appearing when there is a regex match.
