### PR TITLE
Add windows compatibility

### DIFF
--- a/src/periscope.ts
+++ b/src/periscope.ts
@@ -358,7 +358,7 @@ export const periscope = () => {
     }
 
     const { filePath, linePos, colPos } = currentItem.data;
-    vscode.workspace.openTextDocument(filePath).then(document => {
+    vscode.workspace.openTextDocument(path.resolve(filePath)).then(document => {
       vscode.window
         .showTextDocument(document, {
           preview: true,
@@ -377,7 +377,7 @@ export const periscope = () => {
     }
 
     const { filePath, linePos, colPos } = currentItem.data;
-    vscode.workspace.openTextDocument(filePath).then(document => {
+    vscode.workspace.openTextDocument(path.resolve(filePath)).then(document => {
       const options: vscode.TextDocumentShowOptions = {};
 
       if(item) { // horizontal split

--- a/src/periscope.ts
+++ b/src/periscope.ts
@@ -304,7 +304,7 @@ export const periscope = () => {
       : [];
 
     const excludes = config.rgGlobExcludes.map(exclude => {
-      return `--glob '!${exclude}'`;
+      return `--glob "!${exclude}"`;
     });
 
     const rgFlags = [
@@ -317,7 +317,7 @@ export const periscope = () => {
       ...excludes,
     ];
 
-    return `"${rgPath}" '${value}' ${rgFlags.join(' ')}`;
+    return `"${rgPath}" "${value}" ${rgFlags.join(' ')}`;
   }
 
   // extract rg flags from the query, can match multiple regex's


### PR DESCRIPTION
Hi there,

I wanted to try out your awesome extension and realized it did not work on windows. I looked into it and found that the colons from the ripgrep text output conflict with the existing splitting logic. I decided to try to solve those issues and propose:

- Use the ripgrep `--json` flag and parse the output to be more os independant
- Use `path.resolve` to be able open both unix and windows paths
- Use `"` instead of `'` in ripgrep command because windows command line doens't handle the single quotes well

I tested this on windows and inside wsl2, which both worked for me.