### PR TITLE
feat: Add periscope.searchWithSelection command

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
         "title": "Periscope: Search"
       },
       {
+        "command": "periscope.searchWithSelection",
+        "title": "Periscope: Search with Selection"
+      },
+      {
         "command": "periscope.openInHorizontalSplit",
         "title": "Periscope: Open Result in Horizontal Split",
         "enablement": "periscopeActive"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,9 +7,13 @@ export function activate(context: vscode.ExtensionContext) {
 
   const periscopeQpCmd = vscode.commands.registerCommand('periscope.search', () => PERISCOPE.search());
 
+  const periscopeQpWithSelectionCmd = vscode.commands.registerCommand('periscope.searchWithSelection', () =>
+    PERISCOPE.searchWithSelection(),
+  );
+
   const periscopeSplitCmd = vscode.commands.registerCommand('periscope.openInHorizontalSplit', () =>
     PERISCOPE.openInHorizontalSplit(),
   );
 
-  context.subscriptions.push(periscopeQpCmd, periscopeSplitCmd);
+  context.subscriptions.push(periscopeQpCmd, periscopeQpWithSelectionCmd, periscopeSplitCmd);
 }

--- a/src/lib/periscope.ts
+++ b/src/lib/periscope.ts
@@ -2,8 +2,9 @@ import { context as cx } from './context';
 import { onDidHide, setupQuickPickForQuery, setupRgMenuActions } from './quickpickActions';
 import { start } from './globalActions';
 import { openInHorizontalSplit } from './editorActions';
+import { getSelectedText } from '../utils/getSelectedText';
 
-function search() {
+function search(useSelection = false) {
   start();
 
   // if ripgrep actions are available then open preliminary quickpick
@@ -18,9 +19,17 @@ function search() {
 
   // search logic is triggered from the QuickPick event handlers...
   cx.qp.show();
+
+  if (useSelection) {
+    const selectedText = getSelectedText();
+    if (selectedText) {
+      cx.qp.value = selectedText;
+    }
+  }
 }
 
 export const PERISCOPE = {
   search,
+  searchWithSelection: () => search(true),
   openInHorizontalSplit,
 };


### PR DESCRIPTION
This PR adds another command, "periscope.searchWithSelection," that uses the current selection to perform the search immediately.

PS. Thanks for the extensions, it's quite handy! :)