### PR TITLE
feat: add periscope.resumeSearch command to restore previous queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 .cursorrules
 .clinerules
 docs/
+requirements/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ _Inspired by nvim's [telescope](https://github.com/nvim-telescope/telescope.nvim
 - **Fast Search**: Utilizes `ripgrep` for lightning-fast search capabilities.
 - **Real-Time Preview**: See preview of files right in the search pane as you navigate through search results.
 - **Customizable**: Extensive configuration options to tailor search behavior and UI to your needs.
+- **Resume Search**: Quickly resume your last search with a single command.
 
 ![Demo](https://github.com/joshmu/periscope/blob/master/assets/demo.gif?raw=true)
 
@@ -31,6 +32,7 @@ For optimal performance, ensure that the VSCode configuration _Editor: Enable Pr
 - **Raw Queries**: Enclosing your `search_term` in quotes will allow additional ripgrep parameters to be passed through. eg: `"foobar" -t js` will search for `foobar` in js files.
 - **Utilise `rgQueryParams`**: Create shortcuts for common ripgrep search queries via regex matching against your current query. This provides a way to map your query to ripgrep parameters via capture groups in the regex for faster lookups.
 - **Search Current File Only**: Use `periscope.searchCurrentFile` command if you wish to narrow your search to the current file only
+- **Resume Last Search**: Use `periscope.resumeSearch` to instantly restore your previous search query. The extension remembers whether you were searching the workspace or current file.
 
 If you use vim within vscode you can bind `periscope.search` in your `settings.json`:
 
@@ -147,6 +149,7 @@ This extension contributes the following settings:
 
 - `periscope.search`: Enable Periscope Search
 - `periscope.searchCurrentFile`: Enable Periscope Search (current file only)
+- `periscope.resumeSearch`: Resume the last search query
 - `periscope.openInHorizontalSplit`: Open the result preview in a horizontal split.
 
 ## Troubleshooting

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
         "command": "periscope.openInHorizontalSplit",
         "title": "Periscope: Open Result in Horizontal Split",
         "enablement": "periscopeActive"
+      },
+      {
+        "command": "periscope.resumeSearch",
+        "title": "Periscope: Resume Search"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,19 +11,28 @@ export function activate(context: vscode.ExtensionContext) {
   log('activate');
 
   const periscopeQpCmd = vscode.commands.registerCommand('periscope.search', () =>
-    PERISCOPE.search(),
+    PERISCOPE.search(context),
   );
 
   const periscopeSearchCurrentFileQpCmd = vscode.commands.registerCommand(
     'periscope.searchCurrentFile',
-    () => PERISCOPE.search({ currentFileOnly: true }),
+    () => PERISCOPE.search(context, { currentFileOnly: true }),
   );
 
   const periscopeSplitCmd = vscode.commands.registerCommand('periscope.openInHorizontalSplit', () =>
     PERISCOPE.openInHorizontalSplit(),
   );
 
-  context.subscriptions.push(periscopeQpCmd, periscopeSearchCurrentFileQpCmd, periscopeSplitCmd);
+  const periscopeResumeCmd = vscode.commands.registerCommand('periscope.resumeSearch', () =>
+    PERISCOPE.resumeSearch(context),
+  );
+
+  context.subscriptions.push(
+    periscopeQpCmd,
+    periscopeSearchCurrentFileQpCmd,
+    periscopeSplitCmd,
+    periscopeResumeCmd,
+  );
 }
 
 export function deactivate() {

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -37,6 +37,10 @@ export const context = {
    * Disabled by default, is set if extension is invoked with the current file only flag
    */
   currentFileOnly: false,
+  /**
+   * Extension context for storage operations
+   */
+  extensionContext: undefined as vscode.ExtensionContext | undefined,
 };
 
 // reset the context
@@ -55,6 +59,7 @@ function resetContext() {
     query: [],
   };
   context.currentFileOnly = false;
+  // Keep 'extensionContext' across resets to preserve search history
 }
 
 type AppState = 'IDLE' | 'SEARCHING' | 'FINISHED';

--- a/src/lib/periscope.ts
+++ b/src/lib/periscope.ts
@@ -1,11 +1,22 @@
+import * as vscode from 'vscode';
 import { context as cx } from './context';
 import { onDidHide, setupQuickPickForQuery, setupRgMenuActions } from './quickpickActions';
 import { start } from './globalActions';
 import { openInHorizontalSplit } from './editorActions';
 import { setCurrentFileContext } from '../utils/searchCurrentFile';
+import { getLastQuery } from './storage';
 
-function search({ currentFileOnly = false }: { currentFileOnly?: boolean } = {}) {
+function search(
+  extensionContext?: vscode.ExtensionContext,
+  {
+    currentFileOnly = false,
+    initialQuery = '',
+  }: { currentFileOnly?: boolean; initialQuery?: string } = {},
+) {
   start();
+
+  // Store the extension context for storage operations
+  cx.extensionContext = extensionContext;
 
   if (currentFileOnly) {
     setCurrentFileContext();
@@ -14,9 +25,9 @@ function search({ currentFileOnly = false }: { currentFileOnly?: boolean } = {})
   // if ripgrep actions are available then open preliminary quickpick
   const showRgMenuActions = cx.config.alwaysShowRgMenuActions && cx.config.rgMenuActions.length > 0;
   if (showRgMenuActions) {
-    setupRgMenuActions();
+    setupRgMenuActions(initialQuery);
   } else {
-    setupQuickPickForQuery();
+    setupQuickPickForQuery(initialQuery);
   }
 
   cx.disposables.general.push(cx.qp.onDidHide(onDidHide));
@@ -25,7 +36,21 @@ function search({ currentFileOnly = false }: { currentFileOnly?: boolean } = {})
   cx.qp.show();
 }
 
+function resumeSearch(extensionContext: vscode.ExtensionContext) {
+  const lastSearch = getLastQuery(extensionContext);
+  if (lastSearch) {
+    search(extensionContext, {
+      currentFileOnly: lastSearch.type === 'currentFile',
+      initialQuery: lastSearch.query,
+    });
+  } else {
+    // No history, just open empty search
+    search(extensionContext);
+  }
+}
+
 export const PERISCOPE = {
   search,
+  resumeSearch,
   openInHorizontalSplit,
 };

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,88 @@
+import * as vscode from 'vscode';
+import { log } from '../utils/log';
+
+const STORAGE_KEY = 'periscope.searchHistory';
+const MAX_HISTORY_SIZE = 10;
+
+interface StoredQuery {
+  query: string;
+  timestamp: number;
+  type: 'workspace' | 'currentFile';
+}
+
+// In-memory fallback storage
+let inMemoryHistory: StoredQuery[] = [];
+
+export function saveQuery(
+  extensionContext: vscode.ExtensionContext | undefined,
+  query: string,
+  isCurrentFileSearch: boolean,
+): void {
+  if (!query.trim()) {
+    return;
+  }
+
+  const storedQuery: StoredQuery = {
+    query,
+    timestamp: Date.now(),
+    type: isCurrentFileSearch ? 'currentFile' : 'workspace',
+  };
+
+  try {
+    if (extensionContext) {
+      // Get existing history
+      const history = extensionContext.workspaceState.get<StoredQuery[]>(STORAGE_KEY, []);
+
+      // Add new query to the front
+      history.unshift(storedQuery);
+
+      // Limit history size
+      if (history.length > MAX_HISTORY_SIZE) {
+        history.splice(MAX_HISTORY_SIZE);
+      }
+
+      // Save updated history
+      extensionContext.workspaceState.update(STORAGE_KEY, history);
+      log(`Saved query to workspace state history`);
+    } else {
+      // Fallback to in-memory storage
+      inMemoryHistory.unshift(storedQuery);
+      if (inMemoryHistory.length > MAX_HISTORY_SIZE) {
+        inMemoryHistory.splice(MAX_HISTORY_SIZE);
+      }
+      log(`Saved query to in-memory history`);
+    }
+  } catch (error) {
+    // Silent fallback to in-memory storage
+    inMemoryHistory.unshift(storedQuery);
+    if (inMemoryHistory.length > MAX_HISTORY_SIZE) {
+      inMemoryHistory.splice(MAX_HISTORY_SIZE);
+    }
+    log(`Storage error, using in-memory fallback: ${error}`);
+  }
+}
+
+export function getLastQuery(
+  extensionContext: vscode.ExtensionContext | undefined,
+): StoredQuery | undefined {
+  try {
+    if (extensionContext) {
+      // Try to get from workspace state
+      const history = extensionContext.workspaceState.get<StoredQuery[]>(STORAGE_KEY, []);
+      if (history.length > 0) {
+        log(`Retrieved query from workspace state history`);
+        return history[0];
+      }
+    }
+
+    // Check in-memory storage as fallback
+    if (inMemoryHistory.length > 0) {
+      log(`Retrieved query from in-memory history`);
+      return inMemoryHistory[0];
+    }
+  } catch (error) {
+    log(`Error retrieving query: ${error}`);
+  }
+
+  return undefined;
+}

--- a/src/test/suite/periscope.test.ts
+++ b/src/test/suite/periscope.test.ts
@@ -48,7 +48,7 @@ suite('Periscope Core', () => {
     activate(mockContext);
 
     // Verify command registration
-    assert.strictEqual(registerCommandStub.callCount, 3, 'Should register three commands');
+    assert.strictEqual(registerCommandStub.callCount, 4, 'Should register four commands');
     assert.strictEqual(
       registerCommandStub.firstCall.args[0],
       'periscope.search',
@@ -64,9 +64,14 @@ suite('Periscope Core', () => {
       'periscope.openInHorizontalSplit',
       'Should register horizontal split command',
     );
+    assert.strictEqual(
+      registerCommandStub.getCall(3).args[0],
+      'periscope.resumeSearch',
+      'Should register resume search command',
+    );
 
     // Verify commands are added to subscriptions
-    assert.strictEqual(mockContext.subscriptions.length, 3, 'Should add commands to subscriptions');
+    assert.strictEqual(mockContext.subscriptions.length, 4, 'Should add commands to subscriptions');
   });
 
   test('should perform search operation', async () => {


### PR DESCRIPTION
## Summary
- Implements telescope-like resume functionality requested in issue #90
- Adds single `periscope.resumeSearch` command that restores the last search
- Remembers search context (workspace vs current file) for proper restoration

## Changes
- ✨ New `periscope.resumeSearch` command
- 📦 Array-based history storage (up to 10 queries)
- 💾 Persistent storage using VSCode workspaceState API
- 🔄 Graceful fallback to in-memory storage
- 📚 Updated documentation

Closes #90