### PR TITLE
Fix sticky context bug in resume search functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For optimal performance, ensure that the VSCode configuration _Editor: Enable Pr
 - **Raw Queries**: Enclosing your `search_term` in quotes will allow additional ripgrep parameters to be passed through. eg: `"foobar" -t js` will search for `foobar` in js files.
 - **Utilise `rgQueryParams`**: Create shortcuts for common ripgrep search queries via regex matching against your current query. This provides a way to map your query to ripgrep parameters via capture groups in the regex for faster lookups.
 - **Search Current File Only**: Use `periscope.searchCurrentFile` command if you wish to narrow your search to the current file only
-- **Resume Last Search**: Use `periscope.resumeSearch` to instantly restore your previous search query. The extension remembers whether you were searching the workspace or current file.
+- **Resume Last Search**: Use `periscope.resumeSearch` to instantly restore your previous search query, or `periscope.resumeSearchCurrentFile` to resume in the current file.
 
 If you use vim within vscode you can bind `periscope.search` in your `settings.json`:
 
@@ -150,6 +150,7 @@ This extension contributes the following settings:
 - `periscope.search`: Enable Periscope Search
 - `periscope.searchCurrentFile`: Enable Periscope Search (current file only)
 - `periscope.resumeSearch`: Resume the last search query
+- `periscope.resumeSearchCurrentFile`: Resume the last search query (current file)
 - `periscope.openInHorizontalSplit`: Open the result preview in a horizontal split.
 
 ## Troubleshooting

--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
       {
         "command": "periscope.resumeSearch",
         "title": "Periscope: Resume Search"
+      },
+      {
+        "command": "periscope.resumeSearchCurrentFile",
+        "title": "Periscope: Resume Search (Current File)"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,11 +30,17 @@ export function activate(context: vscode.ExtensionContext) {
     PERISCOPE.resumeSearch(context),
   );
 
+  const periscopeResumeCurrentFileCmd = vscode.commands.registerCommand(
+    'periscope.resumeSearchCurrentFile',
+    () => PERISCOPE.resumeSearchCurrentFile(context),
+  );
+
   context.subscriptions.push(
     periscopeQpCmd,
     periscopeSearchCurrentFileQpCmd,
     periscopeSplitCmd,
     periscopeResumeCmd,
+    periscopeResumeCurrentFileCmd,
   );
 }
 

--- a/src/lib/periscope.ts
+++ b/src/lib/periscope.ts
@@ -40,7 +40,7 @@ function resumeSearch(extensionContext: vscode.ExtensionContext) {
   const lastSearch = getLastQuery(extensionContext);
   if (lastSearch) {
     search(extensionContext, {
-      currentFileOnly: lastSearch.type === 'currentFile',
+      currentFileOnly: false,
       initialQuery: lastSearch.query,
     });
   } else {
@@ -49,8 +49,22 @@ function resumeSearch(extensionContext: vscode.ExtensionContext) {
   }
 }
 
+function resumeSearchCurrentFile(extensionContext: vscode.ExtensionContext) {
+  const lastSearch = getLastQuery(extensionContext);
+  if (lastSearch) {
+    search(extensionContext, {
+      currentFileOnly: true,
+      initialQuery: lastSearch.query,
+    });
+  } else {
+    // No history, just open empty search with current file context
+    search(extensionContext, { currentFileOnly: true });
+  }
+}
+
 export const PERISCOPE = {
   search,
   resumeSearch,
+  resumeSearchCurrentFile,
   openInHorizontalSplit,
 };

--- a/src/lib/quickpickActions.ts
+++ b/src/lib/quickpickActions.ts
@@ -70,7 +70,7 @@ function onDidChangeValue(value: string) {
 
   // Save the query for resume functionality
   if (rgQuery.trim()) {
-    saveQuery(cx.extensionContext, rgQuery, cx.currentFileOnly);
+    saveQuery(cx.extensionContext, rgQuery);
   }
 }
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -7,7 +7,6 @@ const MAX_HISTORY_SIZE = 10;
 interface StoredQuery {
   query: string;
   timestamp: number;
-  type: 'workspace' | 'currentFile';
 }
 
 // In-memory fallback storage
@@ -16,7 +15,6 @@ let inMemoryHistory: StoredQuery[] = [];
 export function saveQuery(
   extensionContext: vscode.ExtensionContext | undefined,
   query: string,
-  isCurrentFileSearch: boolean,
 ): void {
   if (!query.trim()) {
     return;
@@ -25,7 +23,6 @@ export function saveQuery(
   const storedQuery: StoredQuery = {
     query,
     timestamp: Date.now(),
-    type: isCurrentFileSearch ? 'currentFile' : 'workspace',
   };
 
   try {

--- a/src/test/suite/periscope.test.ts
+++ b/src/test/suite/periscope.test.ts
@@ -48,7 +48,7 @@ suite('Periscope Core', () => {
     activate(mockContext);
 
     // Verify command registration
-    assert.strictEqual(registerCommandStub.callCount, 4, 'Should register four commands');
+    assert.strictEqual(registerCommandStub.callCount, 5, 'Should register five commands');
     assert.strictEqual(
       registerCommandStub.firstCall.args[0],
       'periscope.search',
@@ -69,11 +69,16 @@ suite('Periscope Core', () => {
       'periscope.resumeSearch',
       'Should register resume search command',
     );
+    assert.strictEqual(
+      registerCommandStub.getCall(4).args[0],
+      'periscope.resumeSearchCurrentFile',
+      'Should register resume search current file command',
+    );
 
-    // Verify commands are added to subscriptions (4 commands + 1 output channel)
+    // Verify commands are added to subscriptions (5 commands + 1 output channel)
     assert.strictEqual(
       mockContext.subscriptions.length,
-      5,
+      6,
       'Should add commands and output channel to subscriptions',
     );
   });


### PR DESCRIPTION
## Summary
Fixes a bug where the resume search feature could get "stuck" in current file search mode, preventing users from resuming workspace searches.

## Changes
- Removed `type` field from stored search history (was storing 'workspace' or 'currentFile')
- Added new `resumeSearchCurrentFile` command for explicit current file resume
- Updated existing `resumeSearch` to always resume in workspace mode
- Updated documentation to reflect the new commands