### PR TITLE
fix(ripgrep): handle paths with spaces by quoting paths

### DIFF
--- a/src/lib/ripgrep.ts
+++ b/src/lib/ripgrep.ts
@@ -34,7 +34,7 @@ function getRgCommand(value: string, extraFlags?: string[]) {
     ...rgRequiredFlags,
     ...config.rgOptions,
     ...cx.rgMenuActionsSelected,
-    ...paths,
+    ...paths.filter((path) => typeof path === 'string').map(ensureQuotedPath),
     ...config.addSrcPaths.map(ensureQuotedPath),
     ...(extraFlags || []),
     ...excludes,


### PR DESCRIPTION
Add quoting of workspace and current-file paths when constructing rg command arguments to ensure paths with spaces are handled correctly. Use getCurrentFilePath defensively so current-file search only runs when a valid path exists. Map paths through ensureQuotedPath and include quoted paths in command flags.

---

The root cause of the problem and how to fix it was quite obvious despite my lack of TypeScript or VSCode extension experience. But I do apologize if the tests are not up to scratch, I had no idea how to go about writing a test for this change, so I had Claude Code write the tests :P

I have also manually tested the change and it does fix the issue, and doesn't seem to break anything else.