### PR TITLE
feat(results): add option to show line numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ If you use vim within vscode you can bind `periscope.search` in your `settings.j
 - `gotoRgMenuActionsPrefix`: If the query starts with this prefix, then open rg menu actions.
 - `enableGotoNativeSearch`: If true, then swap to native vscode search if the custom suffix is entered using the current query.
 - `gotoNativeSearchSuffix`: If the query ends with this suffix, then swap to the native search with the query applied.
+- `showLineNumbers`: If true enabled, append `:<line>` to file path details in results (default: `true`)
 - `peekBorderColor`: Color of the peek border. If not set, uses the editor's find match highlight border color.
 - `peekBorderWidth`: Width of the peek border (default: '2px')
 - `peekBorderStyle`: Style of the peek border (solid, dashed, inset, double, groove, outset, ridge)

--- a/package.json
+++ b/package.json
@@ -248,6 +248,11 @@
           ],
           "default": "solid",
           "description": "Border style for highlighted matching text"
+        },
+        "periscope.showLineNumbers": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show the line number of each match alongside the file path in results."
         }
       }
     }

--- a/src/test/suite/config.test.ts
+++ b/src/test/suite/config.test.ts
@@ -27,6 +27,9 @@ suite('Configuration Tests', () => {
       'solid',
       'Default peekMatchBorderStyle should be solid',
     );
+
+    // showLineNumbers should default to true
+    assert.strictEqual(config.showLineNumbers, true, 'showLineNumbers should default to true');
   });
 
   // ... rest of the tests ...

--- a/src/test/suite/formatPathLabel.test.ts
+++ b/src/test/suite/formatPathLabel.test.ts
@@ -350,4 +350,87 @@ suite('formatPathLabel Tests', () => {
       assert.strictEqual(formatPathLabel(testPath), expected);
     });
   });
+
+  suite('Line Number Suffix', () => {
+    test('appends :line when enabled (with workspace folder)', () => {
+      const getConfigModule = require('../../utils/getConfig');
+      const stub = sandbox.stub(getConfigModule, 'getConfig').returns({
+        showWorkspaceFolderInFilePath: true,
+        startFolderDisplayDepth: 1,
+        endFolderDisplayDepth: 4,
+        startFolderDisplayIndex: 0,
+        showLineNumbers: true,
+      });
+
+      const testPath = createWorkspacePath('src', 'utils', 'file.ts');
+      const expected = createExpectedPath('workspace', 'src', 'utils', 'file.ts');
+      assert.strictEqual(formatPathLabel(testPath, { lineNumber: 99 }), `${expected}:99`);
+
+      stub.restore();
+    });
+
+    test('appends :line when enabled (no workspace folders)', () => {
+      const getConfigModule = require('../../utils/getConfig');
+      const stub = sandbox.stub(getConfigModule, 'getConfig').returns({
+        showWorkspaceFolderInFilePath: true,
+        startFolderDisplayDepth: 1,
+        endFolderDisplayDepth: 4,
+        startFolderDisplayIndex: 0,
+        showLineNumbers: true,
+      });
+      workspaceFoldersStub.get(() => undefined);
+
+      const testPath = createWorkspacePath('src', 'utils', 'file.ts');
+      const actual = formatPathLabel(testPath, { lineNumber: 7 });
+      assert.strictEqual(actual.endsWith(`${testPath}:7`), true);
+
+      stub.restore();
+    });
+
+    test('appends :line when enabled for file outside workspace', () => {
+      const getConfigModule = require('../../utils/getConfig');
+      const stub = sandbox.stub(getConfigModule, 'getConfig').returns({
+        showWorkspaceFolderInFilePath: true,
+        startFolderDisplayDepth: 1,
+        endFolderDisplayDepth: 4,
+        startFolderDisplayIndex: 0,
+        showLineNumbers: true,
+      });
+
+      // Build a path outside the mocked workspace
+      const outsidePath = vscode.Uri.file(
+        path.join('different', 'workspace', 'src', 'file.ts'),
+      ).fsPath;
+
+      const expectedBase = createExpectedPath(
+        'workspace',
+        '...',
+        'different',
+        'workspace',
+        'src',
+        'file.ts',
+      );
+      const result = formatPathLabel(outsidePath, { lineNumber: 321 });
+      assert.strictEqual(result, `${expectedBase}:321`);
+
+      stub.restore();
+    });
+
+    test('does not append when disabled', () => {
+      const getConfigModule = require('../../utils/getConfig');
+      const stub = sandbox.stub(getConfigModule, 'getConfig').returns({
+        showWorkspaceFolderInFilePath: true,
+        startFolderDisplayDepth: 1,
+        endFolderDisplayDepth: 4,
+        startFolderDisplayIndex: 0,
+        showLineNumbers: false,
+      });
+
+      const testPath = createWorkspacePath('src', 'utils', 'file.ts');
+      const expected = createExpectedPath('workspace', 'src', 'utils', 'file.ts');
+      assert.strictEqual(formatPathLabel(testPath, { lineNumber: 3 }), expected);
+
+      stub.restore();
+    });
+  });
 });

--- a/src/test/suite/quickPick.test.ts
+++ b/src/test/suite/quickPick.test.ts
@@ -117,7 +117,7 @@ suite('QuickPick UI', () => {
       _type: 'QuickPickItemQuery',
       label: 'const test = "hello world";',
       data: searchResult,
-      detail: 'src/test.ts',
+      detail: 'src/test.ts:42',
       alwaysShow: true,
       buttons: [
         {
@@ -128,6 +128,46 @@ suite('QuickPick UI', () => {
     };
 
     assert.deepStrictEqual(createResultItem(searchResult), expected);
+  });
+
+  test('should exclude line number in detail when disabled', () => {
+    // Disable line numbers in results via config stub
+    const getConfigModule = require('../../utils/getConfig');
+    const getConfigStub = sandbox.stub(getConfigModule, 'getConfig').returns({
+      showLineNumbers: false,
+    });
+
+    const rawResult: RgMatchResult['rawResult'] = {
+      type: 'match',
+      data: {
+        path: { text: 'src/test.ts' },
+        lines: { text: 'const x = 1;' },
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        line_number: 7,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        absolute_offset: 10,
+        submatches: [
+          {
+            match: { text: 'x' },
+            start: 6,
+            end: 7,
+          },
+        ],
+      },
+    };
+
+    const searchResult: RgMatchResult = {
+      filePath: 'src/test.ts',
+      linePos: 7,
+      colPos: 6,
+      textResult: 'const x = 1;',
+      rawResult,
+    };
+
+    const item = createResultItem(searchResult);
+    assert.strictEqual(item.detail, 'src/test.ts');
+
+    getConfigStub.restore();
   });
 
   test('should handle preview functionality', async () => {
@@ -271,7 +311,7 @@ suite('QuickPick UI', () => {
       peekMinHeight: 3,
       peekLineNumbers: true,
       peekWrapText: true,
-      showLineNumbers: true,
+      showLineNumbers: false,
       showColumnNumbers: true,
       showFullPath: true,
       endFolderDisplayDepth: 2,

--- a/src/utils/formatPathLabel.ts
+++ b/src/utils/formatPathLabel.ts
@@ -8,12 +8,17 @@ import { getConfig } from './getConfig';
  * exposes initial folder display depth and end folder display depth
  * workspace folder name is displayed at the start of the path to provide additional context
  */
-export function formatPathLabel(filePath: string) {
+export function formatPathLabel(filePath: string, options?: { lineNumber?: number }) {
   const { workspaceFolders } = vscode.workspace;
   const config = getConfig();
 
+  let lineNumberSuffix = '';
+  if (typeof options?.lineNumber === 'number' && config.showLineNumbers) {
+    lineNumberSuffix = `:${options.lineNumber}`;
+  }
+
   if (!workspaceFolders) {
-    return filePath;
+    return `${filePath}${lineNumberSuffix}`;
   }
 
   // Handle root path consistently across platforms
@@ -54,5 +59,6 @@ export function formatPathLabel(filePath: string) {
     folders.splice(0, folders.length - config.endFolderDisplayDepth);
     folders.unshift(...initialFolders, '...');
   }
-  return folders.join(path.sep);
+
+  return `${folders.join(path.sep)}${lineNumberSuffix}`;
 }

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -37,5 +37,6 @@ export function getConfig() {
     peekMatchBorderColor: vsConfig.get<string | null>('peekMatchBorderColor', null),
     peekMatchBorderWidth: vsConfig.get<string>('peekMatchBorderWidth', '1px'),
     peekMatchBorderStyle: vsConfig.get<string>('peekMatchBorderStyle', 'solid'),
+    showLineNumbers: vsConfig.get<boolean>('showLineNumbers', false),
   };
 }

--- a/src/utils/quickpickUtils.ts
+++ b/src/utils/quickpickUtils.ts
@@ -10,7 +10,7 @@ export function createResultItem(searchResult: RgMatchResult): QPItemQuery {
     label: searchResult.textResult?.trim(),
     data: searchResult,
     // description: `${folders.join(path.sep)}`,
-    detail: formatPathLabel(searchResult.filePath),
+    detail: formatPathLabel(searchResult.filePath, { lineNumber: searchResult.linePos }),
     /**
      * ! required to support regex
      * otherwise quick pick will automatically remove results that don't have an exact match


### PR DESCRIPTION
- Introduced a new configuration option `periscope.showLineNumbers` to control the display of line numbers alongside file paths in search results. It defaults to `false` to retain existing behavior.
- Updated `formatPathLabel` to append line numbers when enabled.
- Enhanced tests to verify line number functionality in various scenarios.

This is is my second ever tango with TypeScript, so feel free to criticize anything you might be unhappy with. I'm more than happy for feedback and to fix things :)

### Screenshot

<img width="652" height="608" alt="Screen-Capture-2025-08-12-02-51-06" src="https://github.com/user-attachments/assets/bd0aa1f0-a243-4461-9249-3f0d34dc1dff" />
