### PR TITLE
fix(ci): prevent comment posting errors for external contributor PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,9 +55,9 @@ jobs:
         if: runner.os != 'Linux'
         run: npm test
 
-      # Report test status on PR
+      # Report test status on PR (only for PRs from the main repository)
       - name: Update PR Status
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Add condition to only post PR status comments when the PR originates from the main repository. This prevents 403 authentication errors when external contributors submit PRs from forks, as GitHub restricts write permissions for workflows triggered by fork PRs.