### PR TITLE
Close preview tabs on dismiss unless user picked from list

### DIFF
--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -49,6 +49,14 @@ export const context = {
    * Injected ripgrep flags from command arguments
    */
   injectedRgFlags: [] as string[],
+  /**
+   * URIs of documents opened for preview (peek) during this search session
+   */
+  previewOpenedUris: new Set<string>(),
+  /**
+   * URI of the document the user picked by selecting from the list (if any)
+   */
+  pickedUri: undefined as string | undefined,
 };
 
 // reset the context
@@ -68,6 +76,8 @@ function resetContext() {
   };
   context.searchMode = 'all';
   context.injectedRgFlags = [];
+  context.previewOpenedUris = new Set();
+  context.pickedUri = undefined;
   // Keep 'extensionContext' across resets to preserve search history
 }
 

--- a/src/lib/editorActions.ts
+++ b/src/lib/editorActions.ts
@@ -154,6 +154,7 @@ export function peekItem(items: readonly (QPItemQuery | QPItemFile)[]) {
           preserveFocus: true,
         })
         .then((editor) => {
+          cx.previewOpenedUris.add(editor.document.uri.toString());
           // For file items, position at the beginning of the file
           const position = new vscode.Position(0, 0);
           editor.selection = new vscode.Selection(position, position);
@@ -172,6 +173,7 @@ export function peekItem(items: readonly (QPItemQuery | QPItemFile)[]) {
           preserveFocus: true,
         })
         .then((editor) => {
+          cx.previewOpenedUris.add(editor.document.uri.toString());
           setCursorPosition(editor, linePos, colPos, rawResult);
         });
     });
@@ -185,6 +187,10 @@ export function peekBufferItem(items: readonly QPItemBuffer[]) {
   }
 
   vscode.workspace.openTextDocument(currentItem.data.uri).then((document) => {
-    vscode.window.showTextDocument(document, { preview: true, preserveFocus: true });
+    vscode.window
+      .showTextDocument(document, { preview: true, preserveFocus: true })
+      .then((editor) => {
+        cx.previewOpenedUris.add(editor.document.uri.toString());
+      });
   });
 }

--- a/src/lib/globalActions.ts
+++ b/src/lib/globalActions.ts
@@ -40,6 +40,7 @@ export function confirm(payload: ConfirmPayload = { context: 'unknown' }) {
   if (currentItem._type === 'QuickPickItemFile') {
     const { filePath } = currentItem.data;
     vscode.workspace.openTextDocument(path.resolve(filePath)).then((document) => {
+      cx.pickedUri = document.uri.toString();
       const options: vscode.TextDocumentShowOptions = {};
 
       if (payload.context === 'openInHorizontalSplit') {
@@ -61,6 +62,7 @@ export function confirm(payload: ConfirmPayload = { context: 'unknown' }) {
   } else {
     const { filePath, linePos, colPos, rawResult } = currentItem.data;
     vscode.workspace.openTextDocument(path.resolve(filePath)).then((document) => {
+      cx.pickedUri = document.uri.toString();
       const options: vscode.TextDocumentShowOptions = {};
 
       if (payload.context === 'openInHorizontalSplit') {
@@ -94,6 +96,7 @@ export function confirmBuffer(payload: ConfirmBufferPayload = { context: 'unknow
   }
 
   vscode.workspace.openTextDocument(currentItem.data.uri).then((document) => {
+    cx.pickedUri = document.uri.toString();
     vscode.window.showTextDocument(document, options).then(() => cx.qp.dispose());
   });
 }

--- a/src/lib/quickpickActions.ts
+++ b/src/lib/quickpickActions.ts
@@ -133,6 +133,24 @@ function onDidTriggerItemButton(e: vscode.QuickPickItemButtonEvent<AllQPItemVari
 
 // when prompt is 'CANCELLED'
 export function onDidHide() {
+  // Close any tabs that were opened for preview but not picked by the user
+  const tabsToClose: vscode.Tab[] = [];
+  const pickedUri = cx.pickedUri;
+  const previewUris = cx.previewOpenedUris;
+  for (const tabGroup of vscode.window.tabGroups.all) {
+    for (const tab of tabGroup.tabs) {
+      if (tab.input instanceof vscode.TabInputText) {
+        const uriString = tab.input.uri.toString();
+        if (previewUris.has(uriString) && uriString !== pickedUri) {
+          tabsToClose.push(tab);
+        }
+      }
+    }
+  }
+  if (tabsToClose.length > 0) {
+    vscode.window.tabGroups.close(tabsToClose, true);
+  }
+
   if (!cx.qp.selectedItems[0]) {
     if (cx.previousActiveEditor) {
       vscode.window.showTextDocument(


### PR DESCRIPTION
- Track URIs opened for preview (peek) and the URI picked on Enter
- On quick pick hide, close tabs that were preview-only; keep the picked tab
- Applies to search, file search, and buffer list flows

I'm not able to test this but this is my current attempt to address the issue I also commented on in #52. The hope is that this will close any preview tabs that weren't explicitly chosen with *Enter* from the dropdown list of matches. 